### PR TITLE
Lengthen I2C SDA TX hold time

### DIFF
--- a/src/rp2_common/hardware_i2c/i2c.c
+++ b/src/rp2_common/hardware_i2c/i2c.c
@@ -85,6 +85,13 @@ uint i2c_set_baudrate(i2c_inst_t *i2c, uint baudrate) {
     i2c->hw->fs_scl_lcnt = lcnt;
     i2c->hw->fs_spklen = lcnt < 16 ? 1 : lcnt / 16;
 
+    // Set hold time of SDA during transmit to 2. Several I2C devices need
+    // this fix to work well or at all, including the
+    // TCS34725 color sensor, and the SSD1306 and SH1107 OLED drivers.
+    // There is no discernable slowdown in timing traces.
+    i2c->hw->sda_hold =
+        I2C_IC_SDA_HOLD_IC_SDA_RX_HOLD_RESET << I2C_IC_SDA_HOLD_IC_SDA_RX_HOLD_LSB |
+        2 << I2C_IC_SDA_HOLD_IC_SDA_TX_HOLD_LSB;
     i2c->hw->enable = 1;
     return freq_in / period;
 }


### PR DESCRIPTION
Incorporate @fivdi's fix that increases the SDA TX hold time from 1 to 2, as proposed in https://github.com/raspberrypi/pico-sdk/pull/273.

This allows the TCS34725 to operate properly. No other sensors have yet appeared to need this fix, but this is a popular sensor.

I took Saleae traces with and without this fix, and aside from the sensor working properly, I don't see any issues. There is no visible slowdown of I2C transactions, for instance.

Thank you, @fivdi!

A step toward fixing https://github.com/adafruit/circuitpython/issues/4082.